### PR TITLE
git-lfs 3.5.1

### DIFF
--- a/recipe/LICENSE.md
+++ b/recipe/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2014-2016 GitHub, Inc. and Git LFS contributors
+Copyright (c) 2014-2021 GitHub, Inc. and Git LFS contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +19,37 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+Portions of the subprocess and tools directories are copied from Go and are
+under the following license:
+
+Copyright (c) 2010 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Note that Git LFS uses components from other Go modules (included in `vendor/`)
+which are under different licenses.  See those LICENSE files for details.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,4 +2,10 @@
 
 set -o xtrace -o errexit
 
-bash -x install.sh
+#bash -x install.sh
+
+# from https://github.com/git-lfs/git-lfs/blob/main/script/install.sh
+mkdir -p "${PREFIX}/bin"
+for g in git*; do
+  install $g "${PREFIX}/bin/${g}"
+done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,14 +6,14 @@ package:
   version: {{ version }}
 
 source:
-  url: {{ download_url }}/v{{ version }}/git-lfs-linux-amd64-v{{ version }}.tar.gz  # [linux]
-  sha256: 6f28eb19faa7a968882dca190d92adc82493378b933958d67ceaeb9ebe4d731e  # [linux]
+  url: {{ download_url }}/v{{ version }}/git-lfs-linux-amd64-v{{ version }}.tar.gz  # [linux and x86_64]
+  sha256: 6f28eb19faa7a968882dca190d92adc82493378b933958d67ceaeb9ebe4d731e  # [linux and x86_64]
 
-  url: {{ download_url }}/v{{ version }}/git-lfs-darwin-amd64-v{{ version }}.zip  # [osx]
-  sha256: 23f6c768e22a33dcbb57d6cb67d318dc0edc2b16ac04b15faa803a74a31e8c42  # [osx]
+  url: {{ download_url }}/v{{ version }}/git-lfs-darwin-amd64-v{{ version }}.zip  # [osx and x86_64]
+  sha256: 23f6c768e22a33dcbb57d6cb67d318dc0edc2b16ac04b15faa803a74a31e8c42  # [osx and x86_64]
 
-  url: {{ download_url }}/v{{ version }}/git-lfs-darwin-arm64-v{{ version }}.zip  # [arm64]
-  sha256: 1570833e5011290dff12a18416580bfed576bc797b7b521122916e09adf4622d  # [arm64]
+  url: {{ download_url }}/v{{ version }}/git-lfs-darwin-arm64-v{{ version }}.zip  # [osx and arm64]
+  sha256: 1570833e5011290dff12a18416580bfed576bc797b7b521122916e09adf4622d  # [osx and arm64]
 
   url: {{ download_url }}/v{{ version }}/git-lfs-windows-amd64-v{{ version }}.zip  # [win]
   sha256: 94435072f6b3a6f9064b277760c8340e432b5ede0db8205d369468b9be52c6b6  # [win]
@@ -24,14 +24,13 @@ source:
   url: {{ download_url }}/v{{ version }}/git-lfs-linux-ppc64le-v{{ version }}.tar.gz  # [ppc64le]
   sha256: 2c684eec57322d7bc6212f1567d1dd50a6172ed3175f31228fc0a3c0e0c2ebbc  # [ppc64le]
 
+  url: {{ download_url }}/v{{ version }}/git-lfs-linux-s390x-v{{ version }}.tar.gz  # [s390x]
+  sha256: a30303298d2a0f3f3a95c70e80661bdc0bc96415489374b3812406bac56bdbad  # [s390x]
+
 build:
   number: 0
   binary_relocation: false
   detect_binary_files_with_prefix: false
-
-requirements:
-  build:
-    - git               # [unix]
 
 test:
   commands:
@@ -41,10 +40,13 @@ test:
     - git-lfs --help
 
 about:
-  home: https://git-lfs.github.com/
+  home: https://git-lfs.com/
   license: MIT
+  license_family: MIT
   license_file: {{ environ["RECIPE_DIR"] }}/LICENSE.md
-  summary: An open source Git extension for versioning large files
+  summary: Git extension for versioning large files
+  description: |
+    Git LFS is a command line extension and specification for managing large files with Git.
   dev_url: https://github.com/git-lfs/git-lfs
   doc_url: https://github.com/git-lfs/git-lfs/tree/main/docs
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.13.3" %}
+{% set version = "3.5.1" %}
 {% set download_url = "https://github.com/git-lfs/git-lfs/releases/download" %}
 
 package:
@@ -7,19 +7,22 @@ package:
 
 source:
   url: {{ download_url }}/v{{ version }}/git-lfs-linux-amd64-v{{ version }}.tar.gz  # [linux]
-  sha256: 03197488f7be54cfc7b693f0ed6c75ac155f5aaa835508c64d68ec8f308b04c1  # [linux]
+  sha256: 6f28eb19faa7a968882dca190d92adc82493378b933958d67ceaeb9ebe4d731e  # [linux]
 
   url: {{ download_url }}/v{{ version }}/git-lfs-darwin-amd64-v{{ version }}.zip  # [osx]
-  sha256: 20509abd5291586c53e1c19768e06e7b2cf7d200cdce7b73a8ff2cfd51c49c51  # [osx]
+  sha256: 23f6c768e22a33dcbb57d6cb67d318dc0edc2b16ac04b15faa803a74a31e8c42  # [osx]
+
+  url: {{ download_url }}/v{{ version }}/git-lfs-darwin-arm64-v{{ version }}.zip  # [arm64]
+  sha256: 1570833e5011290dff12a18416580bfed576bc797b7b521122916e09adf4622d  # [arm64]
 
   url: {{ download_url }}/v{{ version }}/git-lfs-windows-amd64-v{{ version }}.zip  # [win]
-  sha256: 7997d2a6e4103af331c73db10860426cb03c5188426d27619e823358493e13e4  # [win]
+  sha256: 94435072f6b3a6f9064b277760c8340e432b5ede0db8205d369468b9be52c6b6  # [win]
 
   url: {{ download_url }}/v{{ version }}/git-lfs-linux-arm64-v{{ version }}.tar.gz  # [aarch64]
-  sha256: 42baf1ec23e9fba197b1a62d09aab1d5dab744da6923009d6f9e4dc6d79df978  # [aarch64]
+  sha256: 4f8700aacaa0fd26ae5300fb0996aed14d1fd0ce1a63eb690629c132ff5163a9  # [aarch64]
 
   url: {{ download_url }}/v{{ version }}/git-lfs-linux-ppc64le-v{{ version }}.tar.gz  # [ppc64le]
-  sha256: bf6eafb1f9aedbdbfed6bed1b6007400d237a3ab82153908892de6ca7ad902f1  # [ppc64le]
+  sha256: 2c684eec57322d7bc6212f1567d1dd50a6172ed3175f31228fc0a3c0e0c2ebbc  # [ppc64le]
 
 build:
   number: 0
@@ -40,7 +43,6 @@ test:
 about:
   home: https://git-lfs.github.com/
   license: MIT
-  license_family: MIT
   license_file: {{ environ["RECIPE_DIR"] }}/LICENSE.md
   summary: An open source Git extension for versioning large files
   dev_url: https://github.com/git-lfs/git-lfs


### PR DESCRIPTION
Changes:
- sync with conda-forge
- refresh license
- add s390x

Note: this is a repack. git-lfs is written in go, for which we don't have good support at the moment.

https://github.com/git-lfs/git-lfs/tree/v3.5.1