### PR TITLE
v3.7.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('go') }}
     - go-licenses           # [not win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "git-lfs" %}
-{% set version = "3.7.0" %}
+{% set version = "3.7.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
     url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
-    sha256: ab173702840627feb5f8a408dd5406fa322f3eadaa69938d9226b183d5be25a6
+    sha256: 0e83566a9e2477e03627e7fd6bf81f01fadbf93dcaf6abd2686fca90f6bac7dd
 
 build:
   number: 0


### PR DESCRIPTION
git-lfs v3.7.1

## Links
- [PKG-11603](https://anaconda.atlassian.net/browse/PKG-11603)
- [upstream](https://github.com/git-lfs/git-lfs/tree/v3.7.1)
- [diff](https://github.com/git-lfs/git-lfs/compare/v3.7.0...v3.7.1)

## Notes
- A newer version of the linter is linting correctly locally with `All checks OK`

[PKG-11603]: https://anaconda.atlassian.net/browse/PKG-11603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ